### PR TITLE
Propose .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.xml]
+trim_trailing_whitespace = false


### PR DESCRIPTION
For the sake of uniformity, I propose to add an `.editorconfig` file to allow everyone that use this editor plugin to enforce the same style.

Please tell me how it should be changed.
